### PR TITLE
Abiliy to eager load `redeemer`

### DIFF
--- a/src/Models/Traits/DefinesModelRelations.php
+++ b/src/Models/Traits/DefinesModelRelations.php
@@ -6,6 +6,7 @@ namespace MichaelRubel\Couponables\Models\Traits;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use MichaelRubel\Couponables\Models\Contracts\CouponPivotContract;
 use MichaelRubel\EnhancedContainer\Call;
 
@@ -28,10 +29,10 @@ trait DefinesModelRelations
     /**
      * The only model allowed to redeem the coupon.
      *
-     * @return Model|null
+     * @return MorphTo
      */
-    public function redeemer(): ?Model
+    public function redeemer(): MorphTo
     {
-        return $this->morphTo()->first();
+        return $this->morphTo();
     }
 }

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -562,8 +562,17 @@ class CouponsTest extends TestCase
             'redeemer_id'   => $this->user->id,
         ]);
 
-        $coupon = Coupon::with('redeemer')->first();
+        Coupon::create([
+            'code'          => 'redeemer-coupon2',
+            'redeemer_type' => $this->user::class,
+            'redeemer_id'   => $this->user->id,
+        ]);
 
-        $this->assertInstanceOf($this->user::class, $coupon->redeemer);
+        $coupons = Coupon::with('redeemer')->get();
+
+        $coupons->each(function (Coupon $coupon) {
+            $this->assertInstanceOf($this->user::class, $coupon->redeemer);
+            $this->assertSame($this->user->id, $coupon->redeemer->id);
+        });
     }
 }

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -552,4 +552,18 @@ class CouponsTest extends TestCase
             'redeemer_id'   => $this->user->id,
         ]);
     }
+
+    /** @test */
+    public function testCanRetrieveRedeemerUsingEagerLoading()
+    {
+        Coupon::create([
+            'code'          => 'redeemer-coupon',
+            'redeemer_type' => $this->user::class,
+            'redeemer_id'   => $this->user->id,
+        ]);
+
+        $coupon = Coupon::with('redeemer')->first();
+
+        $this->assertInstanceOf($this->user::class, $coupon->redeemer);
+    }
 }


### PR DESCRIPTION
Fixes #3 

## B/C
Adds a breaking change for this method in the Cupon model (changed the return type), so this pull request will be shipped at the next major version of the package.