### PR TITLE
Drop Laravel 8 support

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,12 +1,10 @@
 name: bc-check
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
   backwards-compatibility-check:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,10 +1,10 @@
 name: phpstan
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
   larastan:

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,4 +1,4 @@
-name: "pint"
+name: pint
 
 on:
     push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   pint:
+    name: "Running Laravel Pint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,7 +1,10 @@
 name: "Laravel Pint"
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
   pint:

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,4 +1,4 @@
-name: "Laravel Pint"
+name: "pint"
 
 on:
     push:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   pint:
-    name: "Running Laravel Pint check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -10,7 +10,6 @@ jobs:
   pint:
     name: "Running Laravel Pint check"
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,10 @@
 name: run-tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,13 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [^8.71, 9.*]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - testbench: 7.*
             laravel: 9.*
-          - testbench: ^6.6
-            laravel: ^8.71
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [9.*]
+        laravel: ['9.x']
         stability: [prefer-lowest, prefer-stable]
-        include:
-          - testbench: 7.*
-            laravel: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -30,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, sodium
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, fileinfo, sodium
           coverage: xdebug
 
       - name: Setup problem matchers
@@ -40,8 +37,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+            composer require "laravel/framework:${{ matrix.laravel }}" --dev --no-interaction --no-update
+            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover build/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,19 @@
     ],
     "require": {
         "php": "^8.0",
-        "spatie/laravel-package-tools": "^1.10",
-        "michael-rubel/laravel-enhanced-container": "^6.3|^8.0|^9.0"
+        "illuminate/contracts": "^9.0",
+        "spatie/laravel-package-tools": "^1.13",
+        "michael-rubel/laravel-enhanced-container": "^9.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.3",
         "laravel/pint": "^1.2",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^5.10|^6.0",
-        "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.6|^7.0",
+        "nunomaduro/collision": "^6.0",
+        "nunomaduro/larastan": "^2.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5",
-        "roave/backward-compatibility-check": "^6.4|^7.0"
+        "roave/backward-compatibility-check": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## About

Laravel 8 support for security ends on January 24th, 2023. After that date, using this version of the framework would be insecure. The package will drop support of Laravel 8 in the next major version You'll still be able to use an older version of the package if you can't currently upgrade your application to Laravel 9.