### PR TITLE
Add calculation strategies 📈

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $coupon = Coupon::create([
     'value' => '10', // <-- %10
 ]);
 
-$coupon->calc(value: 300); // 270.00
+$coupon->calc(using: 300); // 270.00
 ```
 
 The package supports three types of item cost calculations:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ If something's going wrong, methods `verifyCoupon` and `redeemCoupon` will throw
 ```php
 CouponExpiredException      // Coupon is expired (`expires_at` column).
 InvalidCouponException      // Coupon is not found in the database.
+InvalidCouponTypeException  // Wrong coupon type found in the database (`type` column).
+InvalidCouponValueException // Wrong coupon value passed from the database (`value` column).
 NotAllowedToRedeemException // Coupon is assigned to the specific model (`redeemer` morphs).
 OverLimitException          // Coupon is over the limit for the specific model (`limit` column).
 OverQuantityException       // Coupon is exhausted (`quantity` column).
@@ -148,6 +150,25 @@ This method references the model assigned to redeem the coupon:
 public function redeemer(): ?Model;
 ```
 
+### Calculations
+
+```php
+$coupon = Coupon::create([
+    'code'  => 'my-generated-coupon-code-to-use',
+    'type'  => CouponContract::TYPE_PERCENTAGE, // 'percentage'
+    'value' => '10', // <-- %10
+]);
+
+$coupon->calc(value: 300); // 270.00
+```
+
+The package supports three types of item cost calculations:
+- `subtraction` - subtracts the given value from the value defined in the coupon model;
+- `percentage` - subtracts the given value by the percentage defined in the coupon model;
+- `fixed` - completely ignores the given value and takes the coupon model value instead.
+
+Note: you can find constants for coupon types in the [`CouponContract`](https://github.com/michael-rubel/laravel-couponables/blob/main/src/Models/Contracts/CouponContract.php)
+
 ### Listeners
 If you go event-driven, you can handle package events:
 - [CouponVerified](https://github.com/michael-rubel/laravel-couponables/blob/main/src/Events/CouponVerified.php)
@@ -163,15 +184,15 @@ If you go event-driven, you can handle package events:
 ### Generators
 #### Seeding records with random codes
 ```php
-app(CouponServiceContract::class)->generateCoupons(times: 10, length: 7);
+app(CouponServiceContract::class)->generateCoupons(times: 10, length: 7, [
+    // here you can pass coupon model attributes
+]);
 ```
-
-- Note: This will only fill the `code` column.
 
 #### Adding coupons to redeem only by specified model
 ```php
 app(CouponServiceContract::class)->generateCouponFor($redeemer, 'my-test-code', [
-  // here you can pass parameters from the list above
+  // here you can pass coupon model attributes
 ]);
 ```
 

--- a/config/couponables.php
+++ b/config/couponables.php
@@ -49,13 +49,19 @@ return [
     /*
     | Rounding precision if you use calculations.
     |
+    | See: `MichaelRubel\Couponables\Traits\Concerns\CalculatesCosts`
+    |
     | Default: 2
     */
 
     'round' => 2,
 
+    'round_mode' => PHP_ROUND_HALF_UP,
+
     /*
     | Maximum allowed value to be returned by the calculations.
+    |
+    | See: `MichaelRubel\Couponables\Traits\Concerns\CalculatesCosts`
     |
     | Default: 0
     */

--- a/config/couponables.php
+++ b/config/couponables.php
@@ -49,7 +49,7 @@ return [
     /*
     | Rounding precision if you use calculations.
     |
-    | Default: 3
+    | Default: 2
     */
 
     'round' => 2,

--- a/config/couponables.php
+++ b/config/couponables.php
@@ -46,4 +46,20 @@ return [
 
     'service' => \MichaelRubel\Couponables\Services\CouponService::class,
 
+    /*
+    | Rounding precision if you use calculations.
+    |
+    | Default: 3
+    */
+
+    'round' => 2,
+
+    /*
+    | Maximum allowed value to be returned by the calculations.
+    |
+    | Default: 0
+    */
+
+    'max' => 0,
+
 ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,7 +30,8 @@ parameters:
         - '#Parameter \#1 \$related of method Illuminate\\Database\\Eloquent\\Model\:\:hasMany\(\) expects string, mixed given\.#'
         - '#Unable to resolve the template type TTimesValue in call to method static method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:times\(\)#'
         - '#Method MichaelRubel\\Couponables\\Models\\Coupon\:\:calc\(\) should return float but returns mixed\.#'
-        - '#Parameter \#2 \$precision of function round expects int, mixed given\.#'
+        - '#Parameter \$precision of function round expects int, mixed given\.#'
+        - '#Parameter \$mode of function round expects 1\|2\|3\|4, mixed given\.#'
 
     level: max
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,6 +29,8 @@ parameters:
         - '#Unable to resolve the template type TValue in call to function collect#'
         - '#Parameter \#1 \$related of method Illuminate\\Database\\Eloquent\\Model\:\:hasMany\(\) expects string, mixed given\.#'
         - '#Unable to resolve the template type TTimesValue in call to method static method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:times\(\)#'
+        - '#Method MichaelRubel\\Couponables\\Models\\Coupon\:\:calc\(\) should return float but returns mixed\.#'
+        - '#Parameter \#2 \$precision of function round expects int, mixed given\.#'
 
     level: max
 

--- a/src/Exceptions/InvalidCouponTypeException.php
+++ b/src/Exceptions/InvalidCouponTypeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\Couponables\Exceptions;
+
+class InvalidCouponTypeException extends CouponException
+{
+    /**
+     * @var string
+     */
+    protected $message = 'The coupon type is invalid.';
+
+    /**
+     * @var int
+     */
+    protected $code = 404;
+}

--- a/src/Exceptions/InvalidCouponTypeException.php
+++ b/src/Exceptions/InvalidCouponTypeException.php
@@ -9,7 +9,7 @@ class InvalidCouponTypeException extends CouponException
     /**
      * @var string
      */
-    protected $message = 'The coupon type is invalid.';
+    protected $message = 'The coupon type is invalid. Take a look at ``CouponContract` and review your `type` table column value.';
 
     /**
      * @var int

--- a/src/Exceptions/InvalidCouponTypeException.php
+++ b/src/Exceptions/InvalidCouponTypeException.php
@@ -9,7 +9,7 @@ class InvalidCouponTypeException extends CouponException
     /**
      * @var string
      */
-    protected $message = 'The coupon type is invalid. Take a look at ``CouponContract` and review your `type` table column value.';
+    protected $message = 'The coupon type is invalid. Take a look at `CouponContract` and review your `type` table column value.';
 
     /**
      * @var int

--- a/src/Exceptions/InvalidCouponValueException.php
+++ b/src/Exceptions/InvalidCouponValueException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\Couponables\Exceptions;
+
+class InvalidCouponValueException extends CouponException
+{
+    /**
+     * @var string
+     */
+    protected $message = 'The coupon value cannot be zero or less.';
+
+    /**
+     * @var int
+     */
+    protected $code = 500;
+}

--- a/src/Models/Contracts/CouponContract.php
+++ b/src/Models/Contracts/CouponContract.php
@@ -15,12 +15,12 @@ interface CouponContract
     /**
      * @var string
      */
-    public const TYPE_SUBTRACT = 'subtract';
+    public const TYPE_SUBTRACTION = 'subtraction';
 
     /**
      * @var string
      */
-    public const TYPE_PERCENT = 'percent';
+    public const TYPE_PERCENTAGE = 'percentage';
 
     /**
      * @var string

--- a/src/Models/Contracts/CouponContract.php
+++ b/src/Models/Contracts/CouponContract.php
@@ -7,6 +7,27 @@ namespace MichaelRubel\Couponables\Models\Contracts;
 interface CouponContract
 {
     /*
+    | Coupon type definitions.
+    |
+    | These keys are used to determine the calculation strategy.
+    */
+
+    /**
+     * @var string
+     */
+    public const TYPE_SUBTRACT = 'subtract';
+
+    /**
+     * @var string
+     */
+    public const TYPE_PERCENT = 'percent';
+
+    /**
+     * @var string
+     */
+    public const TYPE_FIXED = 'fixed';
+
+    /*
     | Column definitions.
     |
     | For package's internal purposes.

--- a/src/Models/Coupon.php
+++ b/src/Models/Coupon.php
@@ -10,14 +10,16 @@ use MichaelRubel\Couponables\Models\Contracts\CouponContract;
 use MichaelRubel\Couponables\Models\Traits\DefinesColumnChecks;
 use MichaelRubel\Couponables\Models\Traits\DefinesColumns;
 use MichaelRubel\Couponables\Models\Traits\DefinesModelRelations;
+use MichaelRubel\Couponables\Traits\Concerns\CalculatesCosts;
 use MichaelRubel\EnhancedContainer\Core\CallProxy;
 
 class Coupon extends Model implements CouponContract
 {
-    use HasFactory,
-        DefinesColumns,
-        DefinesColumnChecks,
-        DefinesModelRelations;
+    use HasFactory;
+    use DefinesColumns;
+    use DefinesColumnChecks;
+    use DefinesModelRelations;
+    use CalculatesCosts;
 
     /**
      * The attributes that aren't mass assignable.
@@ -34,6 +36,7 @@ class Coupon extends Model implements CouponContract
     protected $casts = [
         'code'     => 'string',
         'type'     => 'string',
+        'value'    => 'string',
         'data'     => 'collection',
         'quantity' => 'integer',
         'limit'    => 'integer',

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -17,9 +17,9 @@ trait CalculatesCosts
     public function calcByType(float $ofValue): float
     {
         return match ($this->{static::$bindable->getTypeColumn()}) {
-            $this::TYPE_SUBTRACT => $this->subtract($ofValue),
-            $this::TYPE_PERCENT  => $this->percentage($ofValue),
-            $this::TYPE_FIXED    => $this->fixedPrice(),
+            $this::TYPE_SUBTRACTION => $this->subtract($ofValue),
+            $this::TYPE_PERCENTAGE  => $this->percentage($ofValue),
+            $this::TYPE_FIXED       => $this->fixedPrice(),
             default => throw new InvalidCouponTypeException,
         };
     }

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -9,12 +9,14 @@ use MichaelRubel\Couponables\Exceptions\InvalidCouponTypeException;
 trait CalculatesCosts
 {
     /**
+     * Calculate output value based on the coupon type.
+     *
      * @param  float  $ofValue
      *
      * @return float
      * @throws InvalidCouponTypeException
      */
-    public function calcByType(float $ofValue): float
+    public function calc(float $ofValue): float
     {
         return match ($this->{static::$bindable->getTypeColumn()}) {
             $this::TYPE_SUBTRACTION => $this->subtract($ofValue),
@@ -25,6 +27,8 @@ trait CalculatesCosts
     }
 
     /**
+     * Apply the "Subtraction" calculation strategy.
+     *
      * @param  float  $cost
      *
      * @return float
@@ -35,6 +39,8 @@ trait CalculatesCosts
     }
 
     /**
+     * Apply the "Percentage" calculation strategy.
+     *
      * @param  float  $of
      *
      * @return float
@@ -45,6 +51,8 @@ trait CalculatesCosts
     }
 
     /**
+     * Apply the "Fixed Price" calculation strategy.
+     *
      * @return float
      */
     private function fixedPrice(): float

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -11,16 +11,16 @@ trait CalculatesCosts
     /**
      * Calculate output value based on the coupon type.
      *
-     * @param  float  $ofValue
+     * @param  float  $value
      *
      * @return float
      * @throws InvalidCouponTypeException
      */
-    public function calc(float $ofValue): float
+    public function calc(float $value): float
     {
         return match ($this->{static::$bindable->getTypeColumn()}) {
-            $this::TYPE_SUBTRACTION => $this->subtract($ofValue),
-            $this::TYPE_PERCENTAGE  => $this->percentage($ofValue),
+            $this::TYPE_SUBTRACTION => $this->subtract($value),
+            $this::TYPE_PERCENTAGE  => $this->percentage($value),
             $this::TYPE_FIXED       => $this->fixedPrice(),
             default => throw new InvalidCouponTypeException,
         };
@@ -41,13 +41,13 @@ trait CalculatesCosts
     /**
      * Apply the "Percentage" calculation strategy.
      *
-     * @param  float  $of
+     * @param  float  $value
      *
      * @return float
      */
-    private function percentage(float $of): float
+    private function percentage(float $value): float
     {
-        return ($this->{static::$bindable->getValueColumn()} / 100) * $of;
+        return ($this->{static::$bindable->getValueColumn()} / 100) * $value;
     }
 
     /**

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -12,13 +12,13 @@ trait CalculatesCosts
     /**
      * Calculate the output value based on the coupon type.
      *
-     * @param  float  $value
+     * @param  float  $using
      *
      * @return float
      * @throws InvalidCouponTypeException
      * @throws InvalidCouponValueException
      */
-    public function calc(float $value): float
+    public function calc(float $using): float
     {
         $discount = (float) $this->{static::$bindable->getValueColumn()};
 
@@ -27,8 +27,8 @@ trait CalculatesCosts
         }
 
         $result = match ($this->{static::$bindable->getTypeColumn()}) {
-            static::TYPE_SUBTRACTION => $this->subtract($value, $discount),
-            static::TYPE_PERCENTAGE  => $this->percentage($value, $discount),
+            static::TYPE_SUBTRACTION => $this->subtract($using, $discount),
+            static::TYPE_PERCENTAGE  => $this->percentage($using, $discount),
             static::TYPE_FIXED       => $this->fixedPrice($discount),
             default => throw new InvalidCouponTypeException,
         };

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -19,9 +19,9 @@ trait CalculatesCosts
     public function calc(float $value): float
     {
         return match ($this->{static::$bindable->getTypeColumn()}) {
-            $this::TYPE_SUBTRACTION => $this->subtract($value),
-            $this::TYPE_PERCENTAGE  => $this->percentage($value),
-            $this::TYPE_FIXED       => $this->fixedPrice(),
+            static::TYPE_SUBTRACTION => $this->subtract($value),
+            static::TYPE_PERCENTAGE  => $this->percentage($value),
+            static::TYPE_FIXED       => $this->fixedPrice(),
             default => throw new InvalidCouponTypeException,
         };
     }

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -22,14 +22,14 @@ trait CalculatesCosts
     {
         $discount = (float) $this->{static::$bindable->getValueColumn()};
 
-        if ($this->lessOrEqualsZero($discount)) {
+        if ($this->lessOrEqualZero($discount)) {
             throw new InvalidCouponValueException;
         }
 
         $result = match ($this->{static::$bindable->getTypeColumn()}) {
-            static::TYPE_SUBTRACTION => $this->subtract($using, $discount),
-            static::TYPE_PERCENTAGE  => $this->percentage($using, $discount),
-            static::TYPE_FIXED       => $this->fixedPrice($discount),
+            static::TYPE_SUBTRACTION => static::$bindable->subtract($using, $discount),
+            static::TYPE_PERCENTAGE  => static::$bindable->percentage($using, $discount),
+            static::TYPE_FIXED       => static::$bindable->fixedPrice($discount),
             default => throw new InvalidCouponTypeException,
         };
 
@@ -42,15 +42,6 @@ trait CalculatesCosts
     }
 
     /**
-     * @param  float  $value
-     * @return bool
-     */
-    private function lessOrEqualsZero(float $value): bool
-    {
-        return $value <= 0;
-    }
-
-    /**
      * Apply the "Subtraction" calculation strategy.
      *
      * @param  float  $cost
@@ -58,7 +49,7 @@ trait CalculatesCosts
      *
      * @return float
      */
-    private function subtract(float $cost, float $discount): float
+    public function subtract(float $cost, float $discount): float
     {
         return $cost - $discount;
     }
@@ -71,7 +62,7 @@ trait CalculatesCosts
      *
      * @return float
      */
-    private function percentage(float $value, float $discount): float
+    public function percentage(float $value, float $discount): float
     {
         return (1.0 - ($discount / 100)) * $value;
     }
@@ -82,8 +73,17 @@ trait CalculatesCosts
      * @param  float  $discount
      * @return float
      */
-    private function fixedPrice(float $discount): float
+    public function fixedPrice(float $discount): float
     {
         return $discount;
+    }
+
+    /**
+     * @param  float  $value
+     * @return bool
+     */
+    private function lessOrEqualZero(float $value): bool
+    {
+        return $value <= 0;
     }
 }

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -9,7 +9,7 @@ use MichaelRubel\Couponables\Exceptions\InvalidCouponTypeException;
 trait CalculatesCosts
 {
     /**
-     * Calculate output value based on the coupon type.
+     * Calculate the output value based on the coupon type.
      *
      * @param  float  $value
      *

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MichaelRubel\Couponables\Traits\Concerns;
+
+use MichaelRubel\Couponables\Exceptions\InvalidCouponTypeException;
+
+trait CalculatesCosts
+{
+    /**
+     * @param  float  $ofValue
+     *
+     * @return float
+     * @throws InvalidCouponTypeException
+     */
+    public function calcByType(float $ofValue): float
+    {
+        return match ($this->{static::$bindable->getTypeColumn()}) {
+            $this::TYPE_SUBTRACT => $this->subtract($ofValue),
+            $this::TYPE_PERCENT  => $this->percentage($ofValue),
+            $this::TYPE_FIXED    => $this->fixedPrice(),
+            default => throw new InvalidCouponTypeException,
+        };
+    }
+
+    /**
+     * @param  float  $cost
+     *
+     * @return float
+     */
+    private function subtract(float $cost): float
+    {
+        return $cost - $this->{static::$bindable->getValueColumn()};
+    }
+
+    /**
+     * @param  float  $of
+     *
+     * @return float
+     */
+    private function percentage(float $of): float
+    {
+        return ($this->{static::$bindable->getValueColumn()} / 100) * $of;
+    }
+
+    /**
+     * @return float
+     */
+    private function fixedPrice(): float
+    {
+        return (float) $this->{static::$bindable->getValueColumn()};
+    }
+}

--- a/src/Traits/Concerns/CalculatesCosts.php
+++ b/src/Traits/Concerns/CalculatesCosts.php
@@ -33,10 +33,12 @@ trait CalculatesCosts
             default => throw new InvalidCouponTypeException,
         };
 
-        return max(
-            round($result, config('couponables.round') ?? 2),
-            config('couponables.max') ?? 0
+        $rounded = round($result,
+            precision: config('couponables.round') ?? 2,
+            mode: config('couponables.round_mode') ?? PHP_ROUND_HALF_UP
         );
+
+        return max($rounded, config('couponables.max') ?? 0);
     }
 
     /**

--- a/src/Traits/Concerns/GeneratesCoupons.php
+++ b/src/Traits/Concerns/GeneratesCoupons.php
@@ -16,14 +16,19 @@ trait GeneratesCoupons
      *
      * @param  int  $times
      * @param  int  $length
+     * @param  array  $attributes
      *
      * @return Collection
      */
-    public function generateCoupons(int $times = 5, int $length = 7): Collection
+    public function generateCoupons(int $times = 5, int $length = 7, array $attributes = []): Collection
     {
-        return Collection::times($times, fn () => $this->model->create([
-            $this->model->getCodeColumn() => Str::random($length),
-        ]));
+        return Collection::times($times, function () use ($length, $attributes) {
+            $fields = collect([
+                $this->model->getCodeColumn() => Str::random($length),
+            ]);
+
+            $this->model->create($fields->merge($attributes)->toArray());
+        });
     }
 
     /**
@@ -43,8 +48,6 @@ trait GeneratesCoupons
             $this->model->getRedeemerIdColumn()   => $redeemer->id,
         ]);
 
-        return $this->model->create(
-            $fields->merge($attributes)->toArray()
-        );
+        return $this->model->create($fields->merge($attributes)->toArray());
     }
 }

--- a/src/Traits/Concerns/GeneratesCoupons.php
+++ b/src/Traits/Concerns/GeneratesCoupons.php
@@ -16,13 +16,15 @@ trait GeneratesCoupons
      *
      * @param  int  $times
      * @param  int  $length
+     * @param  array  $attributes
      *
      * @return Collection
      */
-    public function generateCoupons(int $times = 5, int $length = 7): Collection
+    public function generateCoupons(int $times = 5, int $length = 7, array $attributes = []): Collection
     {
         return Collection::times($times, fn () => $this->model->create([
             $this->model->getCodeColumn() => Str::random($length),
+            ...$attributes,
         ]));
     }
 
@@ -37,14 +39,11 @@ trait GeneratesCoupons
      */
     public function generateCouponFor(Model $redeemer, string $code, array $attributes = []): CouponContract
     {
-        $fields = collect([
+        return $this->model->create([
             $this->model->getCodeColumn()         => $code,
             $this->model->getRedeemerTypeColumn() => $redeemer->getMorphClass(),
             $this->model->getRedeemerIdColumn()   => $redeemer->id,
+            ...$attributes,
         ]);
-
-        return $this->model->create(
-            $fields->merge($attributes)->toArray()
-        );
     }
 }

--- a/src/Traits/Concerns/GeneratesCoupons.php
+++ b/src/Traits/Concerns/GeneratesCoupons.php
@@ -16,15 +16,13 @@ trait GeneratesCoupons
      *
      * @param  int  $times
      * @param  int  $length
-     * @param  array  $attributes
      *
      * @return Collection
      */
-    public function generateCoupons(int $times = 5, int $length = 7, array $attributes = []): Collection
+    public function generateCoupons(int $times = 5, int $length = 7): Collection
     {
         return Collection::times($times, fn () => $this->model->create([
             $this->model->getCodeColumn() => Str::random($length),
-            ...$attributes,
         ]));
     }
 
@@ -39,11 +37,14 @@ trait GeneratesCoupons
      */
     public function generateCouponFor(Model $redeemer, string $code, array $attributes = []): CouponContract
     {
-        return $this->model->create([
+        $fields = collect([
             $this->model->getCodeColumn()         => $code,
             $this->model->getRedeemerTypeColumn() => $redeemer->getMorphClass(),
             $this->model->getRedeemerIdColumn()   => $redeemer->id,
-            ...$attributes,
         ]);
+
+        return $this->model->create(
+            $fields->merge($attributes)->toArray()
+        );
     }
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -142,6 +142,7 @@ class CalculationsTest extends TestCase
             'type'  => 'percentage',
             'value' => '122',
         ]);
+
         config()->offsetUnset('couponables.max');
         $newPrice = $coupon->calc(using: 200);
         $this->assertSame(0.00, $newPrice);
@@ -167,6 +168,7 @@ class CalculationsTest extends TestCase
             'type'  => 'percentage',
             'value' => '0.7123123',
         ]);
+
         config()->offsetUnset('couponables.round');
         $newPrice = $coupon->calc(using: 200);
         $this->assertSame('198.58', (string) $newPrice);
@@ -198,5 +200,35 @@ class CalculationsTest extends TestCase
         config()->set('couponables.round', 7);
         $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.5753754, $newPrice);
+    }
+
+    /** @test */
+    public function testCalcRoundMode()
+    {
+        $coupon = Coupon::create([
+            'code'  => 'test-code',
+            'type'  => 'fixed',
+            'value' => '1.5',
+        ]);
+
+        config()->set('couponables.round', 0);
+        config()->offsetUnset('couponables.round_mode');
+        $newPrice = $coupon->calc(using: 10);
+        $this->assertSame(2.00, $newPrice);
+
+        config()->set('couponables.round', 0);
+        config()->set('couponables.round_mode', PHP_ROUND_HALF_EVEN);
+        $newPrice = $coupon->calc(using: 10);
+        $this->assertSame(2.00, $newPrice);
+
+        config()->set('couponables.round', 0);
+        config()->set('couponables.round_mode', PHP_ROUND_HALF_DOWN);
+        $newPrice = $coupon->calc(using: 10);
+        $this->assertSame(1.00, $newPrice);
+
+        config()->set('couponables.round', 0);
+        config()->set('couponables.round_mode', PHP_ROUND_HALF_ODD);
+        $newPrice = $coupon->calc(using: 10);
+        $this->assertSame(1.00, $newPrice);
     }
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -12,7 +12,7 @@ class CalculationsTest extends TestCase
     {
         $coupon = Coupon::create([
             'code'  => 'test-code',
-            'type'  => 'subtract',
+            'type'  => 'subtraction',
             'value' => '250', // <-- Amount to subtract.
         ]);
 
@@ -27,7 +27,7 @@ class CalculationsTest extends TestCase
     {
         $coupon = Coupon::create([
             'code'  => 'test-code',
-            'type'  => 'percent',
+            'type'  => 'percentage',
             'value' => '50', // <-- %50.
         ]);
 

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -16,7 +16,7 @@ class CalculationsTest extends TestCase
             'value' => '250', // <-- Amount to subtract.
         ]);
 
-        $newPrice = $coupon->calc(ofValue: 500);
+        $newPrice = $coupon->calc(value: 500);
         // 500.00 - 250.00 = 250.00
 
         $this->assertSame(250.00, $newPrice);
@@ -31,7 +31,7 @@ class CalculationsTest extends TestCase
             'value' => '50', // <-- %50.
         ]);
 
-        $newPrice = $coupon->calc(ofValue: 25002.30);
+        $newPrice = $coupon->calc(value: 25002.30);
         // 25002.30 = Item cost.
 
         $this->assertSame(12501.15, $newPrice);
@@ -46,7 +46,7 @@ class CalculationsTest extends TestCase
             'value' => '25000', // <-- Fixed price for the item.
         ]);
 
-        $newPrice = $coupon->calc(ofValue: 500000);
+        $newPrice = $coupon->calc(value: 500000);
         // We're ignoring the item cost in this case ^.
 
         $this->assertSame(25000.00, $newPrice);
@@ -63,6 +63,6 @@ class CalculationsTest extends TestCase
             'value' => '25',
         ]);
 
-        $coupon->calc(ofValue: 500000);
+        $coupon->calc(value: 500000);
     }
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -16,7 +16,7 @@ class CalculationsTest extends TestCase
             'value' => '250', // <-- Amount to subtract.
         ]);
 
-        $newPrice = $coupon->calcByType(ofValue: 500);
+        $newPrice = $coupon->calc(ofValue: 500);
         // 500.00 - 250.00 = 250.00
 
         $this->assertSame(250.00, $newPrice);
@@ -31,7 +31,7 @@ class CalculationsTest extends TestCase
             'value' => '50', // <-- %50.
         ]);
 
-        $newPrice = $coupon->calcByType(ofValue: 25002.30);
+        $newPrice = $coupon->calc(ofValue: 25002.30);
         // 25002.30 = Item cost.
 
         $this->assertSame(12501.15, $newPrice);
@@ -46,7 +46,7 @@ class CalculationsTest extends TestCase
             'value' => '25000', // <-- Fixed price for the item.
         ]);
 
-        $newPrice = $coupon->calcByType(ofValue: 500000);
+        $newPrice = $coupon->calc(ofValue: 500000);
         // We're ignoring the item cost in this case ^.
 
         $this->assertSame(25000.00, $newPrice);
@@ -63,6 +63,6 @@ class CalculationsTest extends TestCase
             'value' => '25',
         ]);
 
-        $coupon->calcByType(ofValue: 500000);
+        $coupon->calc(ofValue: 500000);
     }
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -2,7 +2,6 @@
 
 namespace MichaelRubel\Couponables\Tests;
 
-use Illuminate\Support\Collection;
 use MichaelRubel\Couponables\Exceptions\InvalidCouponTypeException;
 use MichaelRubel\Couponables\Exceptions\InvalidCouponValueException;
 use MichaelRubel\Couponables\Models\Coupon;

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -17,7 +17,7 @@ class CalculationsTest extends TestCase
             'value' => '250', // <-- Amount to subtract.
         ]);
 
-        $newPrice = $coupon->calc(value: 500);
+        $newPrice = $coupon->calc(using: 500);
         // 500.00 - 250.00 = 250.00
 
         $this->assertSame(250.00, $newPrice);
@@ -32,7 +32,7 @@ class CalculationsTest extends TestCase
             'value' => '10', // <-- %10.
         ]);
 
-        $newPrice = $coupon->calc(value: 300); // 300 = Item cost.
+        $newPrice = $coupon->calc(using: 300); // 300 = Item cost.
 
         $this->assertSame(270.00, $newPrice); // 300 - %10 = 270 left.
     }
@@ -46,7 +46,7 @@ class CalculationsTest extends TestCase
             'value' => '25000', // <-- Fixed price for the item.
         ]);
 
-        $newPrice = $coupon->calc(value: 500000);
+        $newPrice = $coupon->calc(using: 500000);
         // We're ignoring the item cost in this case ^.
 
         $this->assertSame(25000.00, $newPrice);
@@ -63,7 +63,7 @@ class CalculationsTest extends TestCase
             'value' => '25',
         ]);
 
-        $coupon->calc(value: 500000);
+        $coupon->calc(using: 500000);
     }
 
     /** @test */
@@ -77,7 +77,7 @@ class CalculationsTest extends TestCase
             'value' => '0',
         ]);
 
-        $coupon->calc(value: 1000);
+        $coupon->calc(using: 1000);
     }
 
     /** @test */
@@ -91,7 +91,7 @@ class CalculationsTest extends TestCase
             'value' => '-1000',
         ]);
 
-        $coupon->calc(value: 1000);
+        $coupon->calc(using: 1000);
     }
 
     /** @test */
@@ -128,7 +128,7 @@ class CalculationsTest extends TestCase
                 'value' => $discount,
             ]);
 
-            $newPrice = $coupon->calc(value: 200);
+            $newPrice = $coupon->calc(using: 200);
 
             $this->assertSame($result, $newPrice);
         });
@@ -143,19 +143,19 @@ class CalculationsTest extends TestCase
             'value' => '122',
         ]);
         config()->offsetUnset('couponables.max');
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(0.00, $newPrice);
 
         config()->set('couponables.max', 0);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(0.00, $newPrice);
 
         config()->set('couponables.max', 1);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(1.00, $newPrice);
 
         config()->set('couponables.max', -1);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(-1.00, $newPrice);
     }
 
@@ -168,35 +168,35 @@ class CalculationsTest extends TestCase
             'value' => '0.7123123',
         ]);
         config()->offsetUnset('couponables.round');
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame('198.58', (string) $newPrice);
 
         config()->set('couponables.round', 1);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame('198.6', (string) $newPrice);
 
         config()->set('couponables.round', 2);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.58, $newPrice);
 
         config()->set('couponables.round', 3);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.575, $newPrice);
 
         config()->set('couponables.round', 4);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.5754, $newPrice);
 
         config()->set('couponables.round', 5);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.57538, $newPrice);
 
         config()->set('couponables.round', 6);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.575375, $newPrice);
 
         config()->set('couponables.round', 7);
-        $newPrice = $coupon->calc(value: 200);
+        $newPrice = $coupon->calc(using: 200);
         $this->assertSame(198.5753754, $newPrice);
     }
 }

--- a/tests/CalculationsTest.php
+++ b/tests/CalculationsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MichaelRubel\Couponables\Tests;
+
+use MichaelRubel\Couponables\Exceptions\InvalidCouponTypeException;
+use MichaelRubel\Couponables\Models\Coupon;
+
+class CalculationsTest extends TestCase
+{
+    /** @test */
+    public function testCanCalcUsingSubtractionStrategy()
+    {
+        $coupon = Coupon::create([
+            'code'  => 'test-code',
+            'type'  => 'subtract',
+            'value' => '250', // <-- Amount to subtract.
+        ]);
+
+        $newPrice = $coupon->calcByType(ofValue: 500);
+        // 500.00 - 250.00 = 250.00
+
+        $this->assertSame(250.00, $newPrice);
+    }
+
+    /** @test */
+    public function testCanCalcUsingPercentStrategy()
+    {
+        $coupon = Coupon::create([
+            'code'  => 'test-code',
+            'type'  => 'percent',
+            'value' => '50', // <-- %50.
+        ]);
+
+        $newPrice = $coupon->calcByType(ofValue: 25002.30);
+        // 25002.30 = Item cost.
+
+        $this->assertSame(12501.15, $newPrice);
+    }
+
+    /** @test */
+    public function testCanCalcUsingFixedStrategy()
+    {
+        $coupon = Coupon::create([
+            'code'  => 'test-code',
+            'type'  => 'fixed',
+            'value' => '25000', // <-- Fixed price for the item.
+        ]);
+
+        $newPrice = $coupon->calcByType(ofValue: 500000);
+        // We're ignoring the item cost in this case ^.
+
+        $this->assertSame(25000.00, $newPrice);
+    }
+
+    /** @test */
+    public function testReturnsSameValueIfTypeNotFound()
+    {
+        $this->expectException(InvalidCouponTypeException::class);
+
+        $coupon = Coupon::create([
+            'code'  => 'test-code',
+            'type'  => 'not-found',
+            'value' => '25',
+        ]);
+
+        $coupon->calcByType(ofValue: 500000);
+    }
+}

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -457,7 +457,7 @@ class CouponsTest extends TestCase
 
         Coupon::create([
             'code'  => $code,
-            'type'  => 'percent',
+            'type'  => 'percentage',
             'value' => '50',
         ]);
 

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -483,7 +483,7 @@ class CouponsTest extends TestCase
             $coupon = $this->user->redeemCoupon($code);
             $this->assertSame('business-coupon', $coupon->code);
 
-            $newPrice = $coupon->calc(ofValue: 150);
+            $newPrice = $coupon->calc(value: 150);
             $this->assertSame(75.0, $newPrice);
         }
     }

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -483,7 +483,7 @@ class CouponsTest extends TestCase
             $coupon = $this->user->redeemCoupon($code);
             $this->assertSame('business-coupon', $coupon->code);
 
-            $newPrice = $coupon->calc(value: 150);
+            $newPrice = $coupon->calc(using: 150);
             $this->assertSame(75.0, $newPrice);
         }
     }

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -483,7 +483,7 @@ class CouponsTest extends TestCase
             $coupon = $this->user->redeemCoupon($code);
             $this->assertSame('business-coupon', $coupon->code);
 
-            $newPrice = $coupon->calcByType(ofValue: 150);
+            $newPrice = $coupon->calc(ofValue: 150);
             $this->assertSame(75.0, $newPrice);
         }
     }

--- a/tests/CouponsTest.php
+++ b/tests/CouponsTest.php
@@ -456,12 +456,9 @@ class CouponsTest extends TestCase
         $code = 'business-coupon';
 
         Coupon::create([
-            'code' => $code,
-            'data' => [
-                'run-jobs' => [
-                    'queue-job-name' => true,
-                ],
-            ],
+            'code'  => $code,
+            'type'  => 'percent',
+            'value' => '50',
         ]);
 
         $this->be($this->user);
@@ -469,14 +466,7 @@ class CouponsTest extends TestCase
         if (! $this->user->isCouponAlreadyUsed($code)) {
             // show different validation errors
             try {
-                $coupon = $this->user->verifyCoupon($code);
-
-                // apply some action if coupon isn't fail
-                // for example get the data from the coupon to identify
-                // which queue job or action to run after coupon is redeemed.
-                if ($coupon->isRedeemedBy($this->user)) {
-                    $this->assertArrayHasKey('queue-job-name', $coupon->data->get('run-jobs'));
-                }
+                $this->user->verifyCoupon($code);
             } catch (InvalidCouponException $e) {
                 $this->assertStringContainsString('The coupon is invalid', $e->getMessage());
             } catch (CouponExpiredException $e) {
@@ -491,8 +481,10 @@ class CouponsTest extends TestCase
 
             // If all set.
             $coupon = $this->user->redeemCoupon($code);
-
             $this->assertSame('business-coupon', $coupon->code);
+
+            $newPrice = $coupon->calcByType(ofValue: 150);
+            $this->assertSame(75.0, $newPrice);
         }
     }
 


### PR DESCRIPTION
## About

Added possibility to calculate a new item cost in the context of the coupon model:

```php
$coupon->calc($itemPrice);
```

### Allowed types:
- `subtraction` - subtracts the given value from the value defined in the coupon model;
- `percentage` - subtracts the given value by the percentage defined in the coupon model;
- `fixed` - completely ignores the given value and takes the coupon model value instead.

---