### PR TITLE
fix isAllowedToRedeemBy method

### DIFF
--- a/src/Models/Coupon.php
+++ b/src/Models/Coupon.php
@@ -184,11 +184,11 @@ class Coupon extends Model implements CouponContract
     {
         return with(static::$bindable, function ($coupon) use ($redeemer) {
             if ($coupon->isMorphColumnsFilled()) {
-                if(empty($coupon->redeemer)){
+                if (empty($coupon->redeemer)) {
                     return false;
                 }
 
-                if(! $coupon->redeemer->is($redeemer)){
+                if (! $coupon->redeemer->is($redeemer)) {
                     return false;
                 }
             }

--- a/src/Models/Coupon.php
+++ b/src/Models/Coupon.php
@@ -183,7 +183,7 @@ class Coupon extends Model implements CouponContract
     public function isAllowedToRedeemBy(Model $redeemer): bool
     {
         return with(static::$bindable, function ($coupon) use ($redeemer) {
-            if ($coupon->isMorphColumnsFilled() && ! $coupon->redeemer()->is($redeemer)) {
+            if ($coupon->isMorphColumnsFilled() && ! $coupon->redeemer->is($redeemer)) {
                 return false;
             }
 

--- a/src/Models/Coupon.php
+++ b/src/Models/Coupon.php
@@ -183,8 +183,14 @@ class Coupon extends Model implements CouponContract
     public function isAllowedToRedeemBy(Model $redeemer): bool
     {
         return with(static::$bindable, function ($coupon) use ($redeemer) {
-            if ($coupon->isMorphColumnsFilled() && ! $coupon->redeemer->is($redeemer)) {
-                return false;
+            if ($coupon->isMorphColumnsFilled()) {
+                if(empty($coupon->redeemer)){
+                    return false;
+                }
+
+                if(! $coupon->redeemer->is($redeemer)){
+                    return false;
+                }
             }
 
             if ($coupon->isOnlyRedeemerTypeFilled() && ! $coupon->isSameRedeemerModel($redeemer)) {


### PR DESCRIPTION
**the issue is:**

when checking a coupon which is registered to a specific user (for example user_id 99), the `verifyCouponOr` will return exception for second check..

for example:
```
$user = User::find(99);
$user->verifyCouponOr("ABC123", function($code, $e){ return $e; }); // 1st time called, success
$user->verifyCouponOr("ABC123", function($code, $e){ return $e; }); // 2nd time, will return NotAllowedToRedeemException (this one should be success also)
```

.
.
**The solution:**

as I check the code, there's a mistake in `isAllowedToRedeemBy` method in `Models\Coupon`:

current redeemer should be compared to coupon's redeemer model instance instead of redeemer query instance

```
$coupon->redeemer()->is($redeemer); // this one wrong
```

```
$coupon->redeemer->is($redeemer); // this one correct one
```

i'm not sure if my solution is correct or not... if not, it's okay and i hope you have a better solution...thank you...

p/s: by the way, sorry for my bad english language....

